### PR TITLE
optimizer_rust: Include log history in fitness

### DIFF
--- a/optimizer_rust/Cargo.toml
+++ b/optimizer_rust/Cargo.toml
@@ -6,9 +6,10 @@ authors = ["Chris Horne <lahwran@lahwran.net>",
             "Melanie Heisey <mheisey.nox@gmail.com"]
 
 [dependencies]
-chrono = "0.2.10"
-rand = "0.3.7"
-argparse = "0.1.3"
+chrono = "0.2.14"
+rand = "0.3.8"
+argparse = "0.2.0"
+rustc-serialize = "0.3"
 
 [profile.release]
 opt-level = 3

--- a/optimizer_rust/src/core.rs
+++ b/optimizer_rust/src/core.rs
@@ -153,7 +153,10 @@ pub fn run(tree: &str, log: &str, pop_str: Option<String>)
         tree
     );
     let mut rng = XorShiftRng::new_unseeded();
-    let fitness_state = try!(process_log(&opt, log));
+    let fitness_state = trylabel!("Parsing log", process_log(&opt, log));
+    let empty_genome = Genome::new(&opt);
+    println!("Fitness of empty genome: {}", fitness(&fitness_state, &opt,
+                                                    &empty_genome));
     let initial_pop = match pop_str {
         None => {
             generate_pop(&opt, &mut rng)
@@ -165,7 +168,7 @@ pub fn run(tree: &str, log: &str, pop_str: Option<String>)
                     continue;
                 }
                 let b = Genome::from_string(&opt, genome_string.trim());
-                let a = try!(b);
+                let a = trylabel!("Parsing genome", b);
                 pop.push(a);
             }
             pop

--- a/optimizer_rust/src/model/genome.rs
+++ b/optimizer_rust/src/model/genome.rs
@@ -10,6 +10,7 @@ use chrono::offset::TimeZone;
 
 use self::NodeType::{Root, Project, Task};
 use self::ActivityType::{Nothing, WorkOn, Finish};
+
 use ::core::Fitness;
 
 use ::model::parse_tree;
@@ -36,7 +37,7 @@ pub struct Node {
     pub subtreesize: usize
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum NodeType {
     Root,
     Project,
@@ -61,7 +62,7 @@ pub fn node_from_str(s: &str) -> Result<Rc<Node>, String> {
 }
 
 impl Activity {
-    fn to_string(&self) -> String {
+    pub fn to_string(&self) -> String {
         let mut result = String::with_capacity(35);
         self.write_to_string(&mut result);
 
@@ -358,6 +359,7 @@ impl Genome {
     pub fn sort(&mut self) {
         self.pool.sort_by(|a, b| a.start.cmp(&b.start));
     }
+
 }
 
 #[derive(Debug, Clone)]

--- a/optimizer_rust/src/model/log.rs
+++ b/optimizer_rust/src/model/log.rs
@@ -1,0 +1,106 @@
+use std::rc::Rc;
+
+use rustc_serialize::json;
+
+use chrono::{UTC, DateTime, TimeZone};
+
+use ::fitness::{TreeState, prepare_state};
+use ::model::genome::{Node,Optimization};
+use ::model::parse_tree;
+
+use self::LogKind::{Activation, Unknown};
+use self::LogNode::{Exists, Gone};
+
+#[derive(Eq, PartialEq)]
+pub enum LogKind {
+    Activation,
+    Unknown
+}
+
+pub enum LogNode {
+    // Currently equivalent to Option. It's fine if that never changes, but
+    // this is intended to elegantly allow adding a "what disappeared"
+    // parameter to Gone, should that be desired (it is greatly expected).
+    Exists(Rc<Node>),
+    Gone
+}
+
+pub struct LogEntry {
+    pub time: DateTime<UTC>,
+    pub kind: LogKind,
+    pub nodes: Vec<LogNode>
+
+}
+
+impl LogEntry {
+    fn from_line(opt: &Optimization, line: &str)
+                -> Result<LogEntry,String> {
+        // 2014-12-17 14:55:21 Wednesday - activation - ["life#00000", "category#Uew2Y: spacemonkey", "task#5Frk3: add setting to restrict uploaded files"]
+        // YYYY-MM-DD HH:MM:SS WEEKDAY - LOGTYPE - JSONNODEPATH
+        // DATE - LOGTYPE - REST
+        let segment_split: Vec<&str> = line.splitn(3, " - ").collect();
+        if segment_split.len() != 3 {
+            return Err("Wrong number of segments".to_string());
+        }
+        let date_split: Vec<&str> = segment_split[0].rsplitn(2, " ").collect();
+        let logkind_data = segment_split[1];
+        let nodes_data = segment_split[2];
+
+        let date = match UTC.datetime_from_str(date_split[0],
+                                               "%Y-%m-%d %H:%M:%S") {
+            Ok(x) => x,
+            Err(error) => return Err(format!("{}", error))
+        };
+
+        let logkind = match logkind_data {
+            "activation" => Activation,
+            _ => Unknown
+        };
+
+        let nodestrings: Vec<String> = json::decode(nodes_data).unwrap();
+        let mut nodes = Vec::new();
+
+        for nodestring in nodestrings {
+            let parsed = try!(parse_tree::parse_line(&nodestring));
+            if parsed.indent != 0 {
+                return Err("A node had nonzero indent in the json".to_string());
+            }
+            if parsed.is_metadata {
+                return Err("Contained metadata in nodes".to_string());
+            }
+            let id = match parsed.id {
+                Some(ref x) => x,
+                None => {
+                    return Err("A node is missing an id".to_string());
+                }
+            };
+
+            nodes.push(match opt.id_map.get(id) {
+                Some(node) => Exists(node.clone()),
+                None => Gone
+            });
+        }
+
+        Ok(LogEntry {
+            time: date,
+            kind: logkind,
+            nodes: nodes
+        })
+    }
+}
+
+pub fn parse_log(opt: &Optimization, log: &str)
+        -> Result<Vec<LogEntry>,String> {
+    let mut result = Vec::new();
+    for (lineidx, line) in log.lines().enumerate() {
+        result.push(tryline!(lineidx, LogEntry::from_line(opt, line)));
+    }
+
+    Ok(result)
+}
+
+pub fn process_log(opt: &Optimization, log: &str) -> Result<TreeState, String> {
+    let parsed = try!(parse_log(opt, log));
+
+    Ok(prepare_state(parsed, opt))
+}

--- a/optimizer_rust/src/model/log.rs
+++ b/optimizer_rust/src/model/log.rs
@@ -46,10 +46,10 @@ impl LogEntry {
         let logkind_data = segment_split[1];
         let nodes_data = segment_split[2];
 
-        let date = match UTC.datetime_from_str(date_split[0],
+        let date = match UTC.datetime_from_str(date_split[1],
                                                "%Y-%m-%d %H:%M:%S") {
             Ok(x) => x,
-            Err(error) => return Err(format!("{}", error))
+            Err(error) => return Err(format!("Date parse: {} - {:?}", error, date_split))
         };
 
         let logkind = match logkind_data {
@@ -61,7 +61,8 @@ impl LogEntry {
         let mut nodes = Vec::new();
 
         for nodestring in nodestrings {
-            let parsed = try!(parse_tree::parse_line(&nodestring));
+            let parsed = trylabel!("Parsing node",
+                                   parse_tree::parse_line(&nodestring));
             if parsed.indent != 0 {
                 return Err("A node had nonzero indent in the json".to_string());
             }

--- a/optimizer_rust/src/model/mod.rs
+++ b/optimizer_rust/src/model/mod.rs
@@ -8,4 +8,5 @@ macro_rules! tryline {
 }
 
 pub mod genome;
+pub mod log;
 mod parse_tree;

--- a/optimizer_rust/src/model/parse_tree.rs
+++ b/optimizer_rust/src/model/parse_tree.rs
@@ -15,11 +15,11 @@ enum Parsing {
 
 #[derive(Debug)]
 pub struct ParsedLine {
-    indent: i32,
-    is_metadata: bool,
-    id: Option<String>,
-    node_type: String,
-    text: Option<String>
+    pub indent: i32,
+    pub is_metadata: bool,
+    pub id: Option<String>,
+    pub node_type: String,
+    pub text: Option<String>
 }
 
 // note: this does not include spaces.
@@ -68,7 +68,7 @@ pub fn parse_line(line: &str) -> Result<ParsedLine, &'static str> {
                     result.is_metadata = true;
                     continue;
                 } else if chr == '-' {
-                    result.node_type = String::from_str("-");
+                    result.node_type = "-".to_string();
                     parsing = Parsing::Sep;
                     continue;
                 }
@@ -188,7 +188,7 @@ impl ParserState {
         while parsed_indent <= self.last_indent {
             self.last_indent -= 1;
             let children = self.peers_stack.pop().unwrap();
-            let (lineidx, parsedline) = self.parent_stack.pop().unwrap();
+            let (_, parsedline) = self.parent_stack.pop().unwrap();
             let nodetype = match parsedline.node_type.parse() {
                 Ok(nt) => nt,
                 // TODO: do something better with ignored nodetypes?
@@ -469,11 +469,6 @@ mod tests {
     #[test]
     fn test_id_required() {
         assert_iserror("ID required", parse("task"));
-    }
-
-    #[test]
-    fn test_invalid_nodetype() {
-        assert_iserror("Invalid node type", parse("derp#abcde"));
     }
 
     #[test]

--- a/optimizer_rust/src/mutate.rs
+++ b/optimizer_rust/src/mutate.rs
@@ -27,7 +27,7 @@ pub fn mutate<R: Rng>(opt: &Optimization, genome: &mut Genome, rng: &mut R) {
     mem::swap(&mut prev_genome, genome);
     let prev_genome_len = prev_genome.pool.len();
 
-    for (index, gene) in prev_genome.pool.drain().enumerate() {
+    for (index, gene) in prev_genome.pool.drain(..).enumerate() {
         if index == prev_genome_len - 1 {
             genome.pool.push(gene);
             break;


### PR DESCRIPTION
Refactors TreeState out into an initial value, calculated from the
user's activity log. This allows the fitness to represent the plans in
the context of the history.

Compiles with rustc 1.2.0-nightly (a9515698f 2015-06-20)

Finishes https://www.pivotaltracker.com/story/show/95831460

@hamnox, please spend ~10 minutes reviewing, and submit if satisfied
